### PR TITLE
Fix composition order

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ to this:
 
 ```js
 const toSlug = compose(
-    encodeURIComponent,
     _ => _.split(" "),
     _ => _.map(str => str.toLowerCase()),
-    _ => _.join("-")
+    _ => _.join("-"),
+    encodeURIComponent
 )
 ```
 


### PR DESCRIPTION
The previous code was equivalent to
`encodeURIComponent(input).split(' ').map(...).join('-')`
instead of the intended
`encodeURIComponent(input.split(' ').map(...).join('-'))`